### PR TITLE
Fix typo in output_width attribute name

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -27,7 +27,7 @@ when 7
   default['yum-cron']['daily']['emitters'] = {
     'system_name' => 'None',
     'emit_via' => 'stdio',
-    'ouput_width' => 80
+    'output_width' => 80
   }
   default['yum-cron']['daily']['email'] = {
     'email_from' => 'root@localhost',
@@ -54,7 +54,7 @@ when 7
   default['yum-cron']['hourly']['emitters'] = {
     'system_name' => 'None',
     'emit_via' => 'stdio',
-    'ouput_width' => 80
+    'output_width' => 80
   }
   default['yum-cron']['hourly']['email'] = {
     'email_from' => 'root@localhost',

--- a/templates/default/yum-cron-hourly.conf.erb
+++ b/templates/default/yum-cron-hourly.conf.erb
@@ -42,7 +42,7 @@ emit_via = <%= @emitters['emit_via'] %>
 
 # The width, in characters, that messages that are emitted should be
 # formatted to.
-ouput_width = <%= @emitters['ouput_width'] %>
+output_width = <%= @emitters['output_width'] %>
 
 
 [email]

--- a/templates/default/yum-cron.conf.erb
+++ b/templates/default/yum-cron.conf.erb
@@ -42,7 +42,7 @@ emit_via = <%= @emitters['emit_via'] %>
 
 # The width, in characters, that messages that are emitted should be
 # formatted to.
-ouput_width = <%= @emitters['ouput_width'] %>
+output_width = <%= @emitters['output_width'] %>
 
 
 [email]

--- a/test/integration/default/serverspec/server_spec.rb
+++ b/test/integration/default/serverspec/server_spec.rb
@@ -40,7 +40,7 @@ else
       its(:content) { should match /update_cmd = default/ }
       its(:content) { should match /system_name = None/ }
       its(:content) { should match /emit_via = stdio/ }
-      its(:content) { should match /ouput_width = 80/ }
+      its(:content) { should match /output_width = 80/ }
       its(:content) { should match /email_from = root@localhost/ }
       its(:content) { should match /email_to = root/ }
       its(:content) { should match /email_host = localhost/ }


### PR DESCRIPTION
While trying out your cookbook on my systems, I ran across a typo in the output_width attribute name (ouput_width). It's also in the stock config file for yum-cron, but the non-typo'd variable name seems to be the correct one.